### PR TITLE
Added datamnom link for elasticsearch/kibana data visualization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ ____
 
 ### Vendor data API via @becdar (Code for Fort Lauderdale)
 https://github.com/becdar/payments-api
+
+### Vendor data injestion tool for import into Elasticsearch and data visualization with Kibana via (@zumbatech)
+
+https://github.com/cjsaylor/datamnom


### PR DESCRIPTION
This adds a link to our #hackforchange hackathon repo.

It contains all information for setting up a VM that contains Elasticsearch and Kibana, and instructions on how to import the flat files provided in this repo.
